### PR TITLE
Add multi-message RabbitMQ subscriber registration

### DIFF
--- a/src/LagoVista.MessageQueue.Rabbit/RabbitMqMessageQueueServiceClient.cs
+++ b/src/LagoVista.MessageQueue.Rabbit/RabbitMqMessageQueueServiceClient.cs
@@ -59,7 +59,8 @@ namespace LagoVista.MessageQueue.Rabbit
             var properties = new BasicProperties
             {
                 ContentType = String.IsNullOrWhiteSpace(route.ContentType) ? "application/json" : route.ContentType,
-                DeliveryMode = route.Persistent ? DeliveryModes.Persistent : DeliveryModes.Transient
+                DeliveryMode = route.Persistent ? DeliveryModes.Persistent : DeliveryModes.Transient,
+                Type = messageType.Name
             };
 
             var json = JsonConvert.SerializeObject(payload);

--- a/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberBuilder.cs
+++ b/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberBuilder.cs
@@ -1,0 +1,79 @@
+using LagoVista.Core.MessageQueue;
+using Microsoft.Extensions.DependencyInjection;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LagoVista.MessageQueue.Rabbit
+{
+    public sealed class RabbitMqSubscriberBuilder
+    {
+        internal IList<RabbitMqSubscriberHandlerRegistration> Registrations { get; }
+            = new List<RabbitMqSubscriberHandlerRegistration>();
+
+        public RabbitMqSubscriberBuilder AddHandler<TMessage, THandler>()
+            where THandler : class, IMessageQueueHandler<TMessage>
+        {
+            Registrations.Add(new RabbitMqSubscriberHandlerRegistration
+            {
+                MessageTypeName = typeof(TMessage).Name,
+                MessageType = typeof(TMessage),
+                HandlerType = typeof(THandler),
+                Dispatcher = new RabbitMqMessageDispatcher<TMessage>()
+            });
+
+            return this;
+        }
+    }
+
+    internal sealed class RabbitMqSubscriberHandlerRegistration
+    {
+        public string MessageTypeName { get; set; }
+        public Type MessageType { get; set; }
+        public Type HandlerType { get; set; }
+        public IRabbitMqMessageDispatcher Dispatcher { get; set; }
+    }
+
+    internal interface IRabbitMqMessageDispatcher
+    {
+        Task DispatchAsync(object payload, BasicDeliverEventArgs args, IServiceProvider serviceProvider, CancellationToken cancellationToken);
+    }
+
+    internal sealed class RabbitMqMessageDispatcher<TMessage> : IRabbitMqMessageDispatcher
+    {
+        public async Task DispatchAsync(object payload, BasicDeliverEventArgs args, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+        {
+            var handler = serviceProvider.GetRequiredService<IMessageQueueHandler<TMessage>>();
+
+            var context = new MessageQueueContext<TMessage>
+            {
+                Payload = (TMessage)payload,
+                MessageId = args.BasicProperties?.MessageId,
+                MessageType = typeof(TMessage).Name,
+                ReceivedAtUtc = DateTime.UtcNow,
+                Headers = ConvertHeaders(args.BasicProperties?.Headers)
+            };
+
+            await handler.HandleAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static IReadOnlyDictionary<string, string> ConvertHeaders(IDictionary<string, object> headers)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (headers == null) return result;
+
+            foreach (var header in headers)
+            {
+                if (header.Value is byte[] bytes)
+                    result[header.Key] = Encoding.UTF8.GetString(bytes);
+                else if (header.Value != null)
+                    result[header.Key] = header.Value.ToString();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberHostedService.MultiMessage.cs
+++ b/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberHostedService.MultiMessage.cs
@@ -34,7 +34,7 @@ namespace LagoVista.MessageQueue.Rabbit
 
         public string Name => $"RabbitMqSubscriberHostedService - {_serviceName}";
 
-        public RabbitMqSubscriberHostedService(string serviceName, RabbitMqSubscriberSettings settings, IEnumerable<RabbitMqSubscriberHandlerRegistration> registrations, ILogger logger, IServiceScopeFactory scopeFactory)
+        internal RabbitMqSubscriberHostedService(string serviceName, RabbitMqSubscriberSettings settings, IEnumerable<RabbitMqSubscriberHandlerRegistration> registrations, ILogger logger, IServiceScopeFactory scopeFactory)
         {
             if (String.IsNullOrWhiteSpace(serviceName)) throw new ArgumentNullException(nameof(serviceName));
             _serviceName = serviceName;

--- a/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberHostedService.MultiMessage.cs
+++ b/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberHostedService.MultiMessage.cs
@@ -1,0 +1,195 @@
+using LagoVista.Core;
+using LagoVista.Core.Interfaces;
+using LagoVista.Core.MessageQueue;
+using LagoVista.Core.Models.Diagnostics;
+using LagoVista.Core.PlatformSupport;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LagoVista.MessageQueue.Rabbit
+{
+    public class RabbitMqSubscriberHostedService : BackgroundService, IHostedServiceDiagnostics
+    {
+        private readonly string _serviceName;
+        private readonly RabbitMqSubscriberSettings _settings;
+        private readonly ILogger _logger;
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ConnectionFactory _connectionFactory;
+        private readonly IReadOnlyDictionary<string, RabbitMqSubscriberHandlerRegistration> _registrations;
+
+        private readonly HostedServiceDiagnosticSnapshot _snapShot = new HostedServiceDiagnosticSnapshot();
+
+        private IConnection _connection;
+        private RabbitMQ.Client.IChannel _channel;
+        private string _consumerTag;
+        private int _processedMessage;
+
+        public string Name => $"RabbitMqSubscriberHostedService - {_serviceName}";
+
+        public RabbitMqSubscriberHostedService(string serviceName, RabbitMqSubscriberSettings settings, IEnumerable<RabbitMqSubscriberHandlerRegistration> registrations, ILogger logger, IServiceScopeFactory scopeFactory)
+        {
+            if (String.IsNullOrWhiteSpace(serviceName)) throw new ArgumentNullException(nameof(serviceName));
+            _serviceName = serviceName;
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+            if (registrations == null) throw new ArgumentNullException(nameof(registrations));
+
+            _settings.Validate(serviceName);
+
+            var registrationLookup = new Dictionary<string, RabbitMqSubscriberHandlerRegistration>(StringComparer.OrdinalIgnoreCase);
+            foreach (var registration in registrations)
+                registrationLookup.Add(registration.MessageTypeName, registration);
+
+            _registrations = registrationLookup;
+
+            _connectionFactory = new ConnectionFactory
+            {
+                ClientProvidedName = $"{nameof(RabbitMqSubscriberHostedService)}:{serviceName}",
+                HostName = _settings.HostName,
+                UserName = _settings.UserName,
+                Password = _settings.Password,
+                VirtualHost = _settings.VirtualHost,
+                Port = _settings.Port,
+                AutomaticRecoveryEnabled = _settings.AutomaticRecoveryEnabled,
+                TopologyRecoveryEnabled = _settings.TopologyRecoveryEnabled,
+                RequestedConnectionTimeout = TimeSpan.FromSeconds(_settings.TimeoutInSeconds <= 0 ? 30 : _settings.TimeoutInSeconds)
+            };
+
+            _connectionFactory.Ssl.Enabled = _settings.UseSsl;
+        }
+
+        public HostedServiceDiagnosticSnapshot GetSnapshot()
+        {
+            return _snapShot;
+        }
+
+        public async Task StartIt()
+        {
+            await ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                _logger.Trace($"{nameof(RabbitMqSubscriberHostedService)} starting '{_serviceName}'.", _serviceName.ToKVP("serviceName"), _settings.QueueName.ToKVP("queueName"), _settings.ExchangeName.ToKVP("destinationName"), _settings.RouteKey.ToKVP("routeKey"));
+
+                await EnsureConnectedAsync(stoppingToken).ConfigureAwait(false);
+
+                var consumer = new AsyncEventingBasicConsumer(_channel);
+                consumer.ReceivedAsync += async (_, args) => await HandleMessageAsync(args, stoppingToken).ConfigureAwait(false);
+
+                _consumerTag = await _channel.BasicConsumeAsync(_settings.QueueName, false, consumer, stoppingToken).ConfigureAwait(false);
+                _snapShot.Status = HostedServiceDiagnosticStatus.Running;
+                _snapShot.StartedUtc = DateTime.UtcNow;
+                _snapShot.LastActivity = "Started";
+                _snapShot.LastActivityUtc = DateTime.UtcNow;
+            }
+            catch (Exception ex)
+            {
+                _logger.AddException($"[RabbitMqSubscriberHostedService__ExecuteAsync__{nameof(RabbitMqSubscriberHostedService)}]", ex, _settings.UserName.ToKVP("userName"), _settings.VirtualHost.ToKVP("vhost"), _serviceName.ToKVP("serviceName"),
+                    _settings.QueueName.ToKVP("queueName"), _settings.ExchangeName.ToKVP("destinationName"), _settings.RouteKey.ToKVP("routeKey"));
+                _snapShot.Status = HostedServiceDiagnosticStatus.Error;
+                _snapShot.LastError = ex.Message;
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+            }
+        }
+
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_channel != null && !_channel.IsClosed && !String.IsNullOrWhiteSpace(_consumerTag))
+            {
+                try
+                {
+                    await _channel.BasicCancelAsync(_consumerTag, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                }
+            }
+
+            await base.StopAsync(cancellationToken).ConfigureAwait(false);
+
+            SafeDispose(_channel);
+            _channel = null;
+
+            SafeDispose(_connection);
+            _connection = null;
+        }
+
+        private async Task EnsureConnectedAsync(CancellationToken cancellationToken)
+        {
+            if (_connection != null && _connection.IsOpen && _channel != null && !_channel.IsClosed) return;
+
+            _connection = await _connectionFactory.CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+            _channel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            await _channel.BasicQosAsync(0, _settings.PrefetchCount, false, cancellationToken).ConfigureAwait(false);
+            await _channel.ExchangeDeclarePassiveAsync(_settings.ExchangeName).ConfigureAwait(false);
+        }
+
+        private async Task HandleMessageAsync(BasicDeliverEventArgs args, CancellationToken cancellationToken)
+        {
+            var messageTypeName = args.BasicProperties?.Type;
+
+            try
+            {
+                if (String.IsNullOrWhiteSpace(messageTypeName))
+                    throw new InvalidOperationException($"RabbitMQ message received by '{_serviceName}' did not contain a message type.");
+
+                if (!_registrations.TryGetValue(messageTypeName, out var registration))
+                    throw new InvalidOperationException($"RabbitMQ subscriber '{_serviceName}' does not have a handler registered for message type '{messageTypeName}'.");
+
+                var json = Encoding.UTF8.GetString(args.Body.ToArray());
+                var payload = JsonConvert.DeserializeObject(json, registration.MessageType);
+                if (payload == null)
+                    throw new InvalidOperationException($"RabbitMQ message body for '{messageTypeName}' could not be deserialized.");
+
+                using var scope = _scopeFactory.CreateScope();
+
+                _snapShot.LastActivityUtc = DateTime.UtcNow;
+                _snapShot.LastActivity = $"Process message {++_processedMessage} ({messageTypeName})";
+
+                await registration.Dispatcher.DispatchAsync(payload, args, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+                await _channel.BasicAckAsync(args.DeliveryTag, false, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _snapShot.LastError = ex.Message;
+                _snapShot.LastErrorUtc = DateTime.UtcNow;
+
+                _logger.AddException($"{nameof(RabbitMqSubscriberHostedService)}__HandleMessageAsync", ex, _serviceName.ToKVP("serviceName"), messageTypeName.ToKVP("messageType"));
+
+                if (_channel != null && !_channel.IsClosed)
+                    await _channel.BasicNackAsync(args.DeliveryTag, false, false, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private static void SafeDispose(IDisposable disposable)
+        {
+            try
+            {
+                disposable?.Dispose();
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberServiceCollectionExtensions.cs
+++ b/src/LagoVista.MessageQueue.Rabbit/RabbitMqSubscriberServiceCollectionExtensions.cs
@@ -2,9 +2,10 @@ using LagoVista.Core.Interfaces;
 using LagoVista.Core.MessageQueue;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace LagoVista.MessageQueue.Rabbit
 {
@@ -22,7 +23,7 @@ namespace LagoVista.MessageQueue.Rabbit
         }
 
         public static IServiceCollection AddRabbitMqSubscriber<TMessage, THandler>(this IServiceCollection services, RabbitMqSubscriberSettings settings, string serviceName)
-    where THandler : class, IMessageQueueHandler<TMessage>
+            where THandler : class, IMessageQueueHandler<TMessage>
         {
             if (services == null) throw new ArgumentNullException(nameof(services));
             if (settings == null) throw new ArgumentNullException(nameof(settings));
@@ -66,6 +67,85 @@ namespace LagoVista.MessageQueue.Rabbit
                 serviceProvider.GetRequiredService<RabbitMqSubscriberHostedService<TMessage>>());
 
             return services;
+        }
+
+        public static IServiceCollection AddRabbitMqSubscriber(this IServiceCollection services, IConfiguration configuration, string sectionName, Action<RabbitMqSubscriberBuilder> configure)
+        {
+            return services.AddRabbitMqSubscriber(configuration, sectionName, sectionName, configure);
+        }
+
+        public static IServiceCollection AddRabbitMqSubscriber(this IServiceCollection services, IConfiguration configuration, string sectionName, string serviceName, Action<RabbitMqSubscriberBuilder> configure)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (String.IsNullOrWhiteSpace(sectionName)) throw new ArgumentNullException(nameof(sectionName));
+
+            var settings = RabbitMqSubscriberSettings.Read(configuration, sectionName);
+            return services.AddRabbitMqSubscriber(settings, serviceName, configure);
+        }
+
+        public static IServiceCollection AddRabbitMqSubscriber(this IServiceCollection services, RabbitMqSubscriberSettings settings, string serviceName, Action<RabbitMqSubscriberBuilder> configure)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+            if (settings == null) throw new ArgumentNullException(nameof(settings));
+            if (String.IsNullOrWhiteSpace(serviceName)) throw new ArgumentNullException(nameof(serviceName));
+            if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+            settings.Validate(serviceName);
+
+            var builder = new RabbitMqSubscriberBuilder();
+            configure(builder);
+
+            ValidateRegistrations(builder.Registrations, serviceName);
+
+            foreach (var registration in builder.Registrations)
+            {
+                services.AddTransient(
+                    typeof(IMessageQueueHandler<>).MakeGenericType(registration.MessageType),
+                    registration.HandlerType);
+            }
+
+            var registrations = builder.Registrations.ToList();
+
+            services.AddSingleton<RabbitMqSubscriberHostedService>(serviceProvider =>
+                new RabbitMqSubscriberHostedService(
+                    serviceName,
+                    settings,
+                    registrations,
+                    serviceProvider.GetRequiredService<LagoVista.Core.PlatformSupport.ILogger>(),
+                    serviceProvider.GetRequiredService<IServiceScopeFactory>()));
+
+            services.AddSingleton<IHostedService>(serviceProvider =>
+                serviceProvider.GetRequiredService<RabbitMqSubscriberHostedService>());
+
+            services.AddSingleton<IHostedServiceDiagnostics>(serviceProvider =>
+                serviceProvider.GetRequiredService<RabbitMqSubscriberHostedService>());
+
+            return services;
+        }
+
+        private static void ValidateRegistrations(IReadOnlyCollection<RabbitMqSubscriberHandlerRegistration> registrations, string serviceName)
+        {
+            if (!registrations.Any())
+                throw new InvalidOperationException($"RabbitMQ subscriber '{serviceName}' must register at least one message handler.");
+
+            var duplicateMessageTypeNames = registrations
+                .GroupBy(x => x.MessageTypeName, StringComparer.OrdinalIgnoreCase)
+                .Where(x => x.Count() > 1)
+                .Select(x => x.Key)
+                .ToList();
+
+            if (duplicateMessageTypeNames.Any())
+                throw new InvalidOperationException($"RabbitMQ subscriber '{serviceName}' contains duplicate message class names: {String.Join(", ", duplicateMessageTypeNames)}.");
+
+            var duplicateMessageTypes = registrations
+                .GroupBy(x => x.MessageType)
+                .Where(x => x.Count() > 1)
+                .Select(x => x.Key.FullName)
+                .ToList();
+
+            if (duplicateMessageTypes.Any())
+                throw new InvalidOperationException($"RabbitMQ subscriber '{serviceName}' contains duplicate message types: {String.Join(", ", duplicateMessageTypes)}.");
         }
     }
 }

--- a/tests/LagoVista.MessageQueueTests/RabbitMqSubscriberServiceCollectionExtensionsTests.cs
+++ b/tests/LagoVista.MessageQueueTests/RabbitMqSubscriberServiceCollectionExtensionsTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -34,6 +35,87 @@ namespace LagoVista.MessageQueue.RabbitMQ.IntegrationTests
             Assert.That(hostedService, Is.TypeOf<RabbitMqSubscriberHostedService<IntegrationMessage>>());
         }
 
+        [Test]
+        public void AddRabbitMqSubscriber_With_Multiple_Handlers_Should_Register_Handlers_And_One_Hosted_Service()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILogger>(new TestAdminLogger());
+
+            var configuration = BuildSubscriberConfiguration("BillingEvents");
+
+            services.AddRabbitMqSubscriber(
+                configuration,
+                "BillingEvents",
+                subscriber =>
+                {
+                    subscriber.AddHandler<TokenUsageRequest, TokenUsageRequestHandler>();
+                    subscriber.AddHandler<BillingUsageRequest, BillingUsageRequestHandler>();
+                });
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var tokenHandler = serviceProvider.GetRequiredService<IMessageQueueHandler<TokenUsageRequest>>();
+            var billingHandler = serviceProvider.GetRequiredService<IMessageQueueHandler<BillingUsageRequest>>();
+            var hostedService = serviceProvider.GetServices<IHostedService>().Single();
+
+            Assert.That(tokenHandler, Is.TypeOf<TokenUsageRequestHandler>());
+            Assert.That(billingHandler, Is.TypeOf<BillingUsageRequestHandler>());
+            Assert.That(hostedService, Is.TypeOf<RabbitMqSubscriberHostedService>());
+            Assert.That(((RabbitMqSubscriberHostedService)hostedService).Name, Does.Contain("BillingEvents"));
+        }
+
+        [Test]
+        public void AddRabbitMqSubscriber_With_Service_Name_Should_Use_Service_Name()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILogger>(new TestAdminLogger());
+
+            var configuration = BuildSubscriberConfiguration("BillingEvents");
+
+            services.AddRabbitMqSubscriber(
+                configuration,
+                "BillingEvents",
+                "billing-events",
+                subscriber => subscriber.AddHandler<TokenUsageRequest, TokenUsageRequestHandler>());
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var hostedService = serviceProvider.GetServices<IHostedService>().Single();
+
+            Assert.That(((RabbitMqSubscriberHostedService)hostedService).Name, Does.Contain("billing-events"));
+        }
+
+        [Test]
+        public void AddRabbitMqSubscriber_With_Duplicate_Message_Class_Names_Should_Throw()
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildSubscriberConfiguration("BillingEvents");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                services.AddRabbitMqSubscriber(
+                    configuration,
+                    "BillingEvents",
+                    subscriber =>
+                    {
+                        subscriber.AddHandler<GenericRequest<TokenUsageRequest>, GenericTokenUsageRequestHandler>();
+                        subscriber.AddHandler<GenericRequest<BillingUsageRequest>, GenericBillingUsageRequestHandler>();
+                    }));
+
+            Assert.That(exception.Message, Does.Contain("duplicate message class names"));
+            Assert.That(exception.Message, Does.Contain("GenericRequest"));
+        }
+
+        [Test]
+        public void AddRabbitMqSubscriber_With_No_Handlers_Should_Throw()
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildSubscriberConfiguration("BillingEvents");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                services.AddRabbitMqSubscriber(configuration, "BillingEvents", subscriber => { }));
+
+            Assert.That(exception.Message, Does.Contain("must register at least one message handler"));
+        }
+
         private static IConfiguration BuildSubscriberConfiguration(string sectionName)
         {
             return new ConfigurationBuilder()
@@ -56,6 +138,42 @@ namespace LagoVista.MessageQueue.RabbitMQ.IntegrationTests
         private sealed class RegisteredIntegrationHandler : IMessageQueueHandler<IntegrationMessage>
         {
             public System.Threading.Tasks.Task HandleAsync(MessageQueueContext<IntegrationMessage> context, System.Threading.CancellationToken cancellationToken = default)
+            {
+                return System.Threading.Tasks.Task.CompletedTask;
+            }
+        }
+
+        private sealed class TokenUsageRequest { }
+        private sealed class BillingUsageRequest { }
+        private sealed class GenericRequest<T> { }
+
+        private sealed class TokenUsageRequestHandler : IMessageQueueHandler<TokenUsageRequest>
+        {
+            public System.Threading.Tasks.Task HandleAsync(MessageQueueContext<TokenUsageRequest> context, System.Threading.CancellationToken cancellationToken = default)
+            {
+                return System.Threading.Tasks.Task.CompletedTask;
+            }
+        }
+
+        private sealed class BillingUsageRequestHandler : IMessageQueueHandler<BillingUsageRequest>
+        {
+            public System.Threading.Tasks.Task HandleAsync(MessageQueueContext<BillingUsageRequest> context, System.Threading.CancellationToken cancellationToken = default)
+            {
+                return System.Threading.Tasks.Task.CompletedTask;
+            }
+        }
+
+        private sealed class GenericTokenUsageRequestHandler : IMessageQueueHandler<GenericRequest<TokenUsageRequest>>
+        {
+            public System.Threading.Tasks.Task HandleAsync(MessageQueueContext<GenericRequest<TokenUsageRequest>> context, System.Threading.CancellationToken cancellationToken = default)
+            {
+                return System.Threading.Tasks.Task.CompletedTask;
+            }
+        }
+
+        private sealed class GenericBillingUsageRequestHandler : IMessageQueueHandler<GenericRequest<BillingUsageRequest>>
+        {
+            public System.Threading.Tasks.Task HandleAsync(MessageQueueContext<GenericRequest<BillingUsageRequest>> context, System.Threading.CancellationToken cancellationToken = default)
             {
                 return System.Threading.Tasks.Task.CompletedTask;
             }


### PR DESCRIPTION
## What changed

- Added additive multi-message subscriber overloads using `RabbitMqSubscriberBuilder`.
- Added a non-generic hosted subscriber that consumes one queue and dispatches by `BasicProperties.Type`.
- Registered handlers with `subscriber.AddHandler<TMessage, THandler>()`.
- Used the short CLR class name as the wire message type.
- Added startup validation for empty registrations, duplicate CLR types, and duplicate short class names.
- Preserved the existing generic `AddRabbitMqSubscriber<TMessage, THandler>` path and hosted service unchanged.
- Added the short class name to published RabbitMQ message properties.
- Added registration tests for the legacy path, multi-handler path, optional service name, empty registrations, and duplicate class names.

## Why

Related message types such as `TokenUsageRequest` and `BillingUsageRequest` should be able to share one operational queue while retaining strongly typed handlers. This avoids creating a new RabbitMQ queue for every DTO without changing existing subscriber behavior.

## Usage

```csharp
services.AddRabbitMqSubscriber(
    configuration,
    "BillingEvents",
    "billing-events",
    subscriber =>
    {
        subscriber.AddHandler<TokenUsageRequest, TokenUsageRequestHandler>();
        subscriber.AddHandler<BillingUsageRequest, BillingUsageRequestHandler>();
    });
```

The service name may be omitted, in which case the configuration section name is used.

## Validation

The branch includes focused NUnit coverage. Local execution was not available in the current tool environment, so CI should provide the build and test confirmation.