### PR TITLE
Add runtime storage marker attribute

### DIFF
--- a/src/LagoVista.Core/Attributes/RuntimeStorageAttribute.cs
+++ b/src/LagoVista.Core/Attributes/RuntimeStorageAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace LagoVista.Core.Attributes
+{
+    /// <summary>
+    /// Marks an entity as runtime document data so document storage can route the
+    /// entity type to its own provider-specific collection/container.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public sealed class RuntimeStorageAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Adds a parameterless `RuntimeStorageAttribute` in `LagoVista.Core.Attributes`.

The marker is intentionally class-only and contains no collection, partition, scope, or provider settings. Its sole purpose is to let document-storage routing identify entity types that should receive dedicated runtime collections/containers.

`EntityDescriptionAttribute.Lifecycle` remains semantic model metadata; `[RuntimeStorage]` is a separate physical storage-routing signal.

## Follow-up

CloudStorage will use this marker once the updated Core dependency is available. Until then, the legacy unused `IsRuntimeData` hook can be removed without changing current shared-collection behavior.