### PR TITLE
Add operational record storage contracts

### DIFF
--- a/src/LagoVista.Core/Interfaces/IOperationalRecord.cs
+++ b/src/LagoVista.Core/Interfaces/IOperationalRecord.cs
@@ -1,0 +1,14 @@
+namespace LagoVista.Core.Interfaces
+{
+    /// <summary>
+    /// Minimal record contract for compact, mutable operational data.
+    /// Operational records represent the current working state used to run the platform
+    /// rather than immutable activity history or document-oriented application data.
+    /// </summary>
+    public interface IOperationalRecord
+    {
+        string Id { get; set; }
+        string OrganizationId { get; set; }
+        string Organization { get; set; }
+    }
+}

--- a/src/LagoVista.Core/Interfaces/IOperationalRecordStore.cs
+++ b/src/LagoVista.Core/Interfaces/IOperationalRecordStore.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LagoVista.Core.Interfaces
+{
+    /// <summary>
+    /// Provider-neutral storage contract for compact, mutable operational records.
+    /// Implementations may use Cassandra or another backend suitable for high-cardinality
+    /// keyed state without exposing provider topology to callers.
+    /// </summary>
+    public interface IOperationalRecordStore<TRecord>
+        where TRecord : class, IOperationalRecord
+    {
+        Task<TRecord> GetAsync(string organizationId, string id, CancellationToken cancellationToken = default);
+        Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default);
+        Task UpsertBatchAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default);
+        Task DeleteAsync(string organizationId, string id, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LagoVista.Core/Interfaces/IOperationalRecordStore.cs
+++ b/src/LagoVista.Core/Interfaces/IOperationalRecordStore.cs
@@ -12,9 +12,9 @@ namespace LagoVista.Core.Interfaces
     public interface IOperationalRecordStore<TRecord>
         where TRecord : class, IOperationalRecord
     {
-        Task<TRecord> GetAsync(string organizationId, string id, CancellationToken cancellationToken = default);
+        Task<TRecord> GetAsync(OperationalRecordKey key, CancellationToken cancellationToken = default);
         Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default);
         Task UpsertBatchAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default);
-        Task DeleteAsync(string organizationId, string id, CancellationToken cancellationToken = default);
+        Task DeleteAsync(OperationalRecordKey key, CancellationToken cancellationToken = default);
     }
 }

--- a/src/LagoVista.Core/Interfaces/OperationalRecordKey.cs
+++ b/src/LagoVista.Core/Interfaces/OperationalRecordKey.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace LagoVista.Core.Interfaces
+{
+    /// <summary>
+    /// Provider-neutral identity for an operational record.
+    /// Scope values describe the logical record boundary (for example repository or instance)
+    /// without exposing provider-specific partition, shard, table, or collection concepts.
+    /// </summary>
+    public sealed class OperationalRecordKey
+    {
+        public OperationalRecordKey(string organizationId, string id, IReadOnlyDictionary<string, string> scope = null)
+        {
+            if (String.IsNullOrWhiteSpace(organizationId)) throw new ArgumentNullException(nameof(organizationId));
+            if (String.IsNullOrWhiteSpace(id)) throw new ArgumentNullException(nameof(id));
+
+            OrganizationId = organizationId;
+            Id = id;
+            Scope = scope ?? new Dictionary<string, string>();
+        }
+
+        public string OrganizationId { get; }
+        public string Id { get; }
+        public IReadOnlyDictionary<string, string> Scope { get; }
+    }
+}


### PR DESCRIPTION
Introduces the provider-neutral Core contracts for compact, mutable operational data.

- `IOperationalRecord` defines minimal operational identity and organization scope.
- `IOperationalRecordStore<TRecord>` defines point get, upsert, batch upsert, and delete behavior.
- `OperationalRecordKey` carries logical scope values without exposing Cassandra partitions, shards, tables, or Mongo collections.

This intentionally does not add query, paging, sharding, TTL, or provider implementation concerns to Core. Those belong in CloudStorage once its current refactor settles.

The first intended consumer is current device connectivity/status, while the abstraction is deliberately broad enough for other high-cardinality operational records.